### PR TITLE
Task/add download geneset commandline tutorial

### DIFF
--- a/docs/reference/command-line/api-commands.md
+++ b/docs/reference/command-line/api-commands.md
@@ -1,0 +1,98 @@
+# API Commands
+
+The `gweave` client has a command group for interacting with the Geneweaver API. This
+allows you to do many of the tasks you would usually do on the website from the command
+line.
+
+This can be useful for automating tasks, or for running analysis tools locally.
+
+## Requirements
+You will need to have installed the `gweave` tool. See 
+[Command Line Interface](/reference/command-line/#installation) for installation instructions.
+
+You will need to have logged in to the `gweave` tool. See
+[Logging In](/reference/command-line/#logging-in) for instructions on how to log in.
+
+## The `api` Command Group
+
+!!! warning "Still in alpha!"
+    The `api` command group is still in alpha! In the following examples we will prepend
+    the `alpha` command group to all of our examples.
+
+The `api` command group collects all api interaction commands into a single group. There
+are several subgroups, each with their own set of commands.
+
+??? info "Command Groups"
+    If you are not familiar with command groups, see the documentation on `gweave`
+    [Command Groups](/reference/command-line/#command-groups).
+
+### Genesets
+
+The `genesets` command group is for interacting with genesets.
+
+You can see up-to-date documentation on the command group by using the following help
+command:
+```
+gweaver alpha api genesets --help
+```
+
+#### Downloading a Geneset
+
+Downloading a geneset can be as simple as specifying the geneset ID (without the `GS`
+prefix).
+
+```
+gweave -p alpha api genesets get $GS_ID
+```
+
+For example, to download geneset `GS1234`, you can use the following command:
+
+```
+gweave -p alpha api genesets get 1234 
+```
+
+If you want to download the geneset in a specific gene ID type, you can specify the
+`--gene-id-type` flag.
+
+```
+gweave -p alpha api genesets get 1234 --gene-id-type=Wormbase
+```
+
+To save the geneset to a file, you can use the `>` operator.
+
+```
+gweave -p alpha api genesets get 1234 --gene-id-type=Wormbase > geneset_123.json
+```
+
+#### Pretty Printing
+The `-p` flag will format the results in a way that is easier to read.
+
+You can save the results to a file by using the `>` operator.
+```
+gweave -p alpha api genesets get 1234 --gene-id-type=Wormbase > geneset_123.json
+```
+
+
+#### GeneIdentifier Types
+
+!!! warning
+    The `GeneIdentifier` types are reproduced here for convenience, but the most 
+    up-to-date list can be found in the `geneweaver-core` package by using the
+    `geneweaver.core.enum.GeneIdentifier` class.
+
+- "Entrez"
+- "Ensemble Gene"
+- "Ensemble Protein"
+- "Ensemble Transcript"
+- "Unigene"
+- "Gene Symbol"
+- "Unannotated"
+- "MGI"
+- "HGNC"
+- "RGD"
+- "ZFIN"
+- "FlyBase"
+- "Wormbase"
+- "SGD"
+- "miRBase"
+- "CGNC"

--- a/docs/reference/command-line/index.md
+++ b/docs/reference/command-line/index.md
@@ -1,0 +1,91 @@
+# `gweave` Command Line Interface
+
+The geneweaver-client library comes with a command line interface that exposes common
+functionality for Geneweaver.
+
+## Installation
+This library is tested on python version `3.9`, `3.10`, and `3.11` on Ubuntu Linux. The 
+library should work on any version of python `3.9` or higher on any system that runs
+python.
+
+!!! tip "Using a Virtual Environment"
+    A virtual environment is a way to isolate the dependencies of a project from the
+    dependencies of the system. This is useful for managing multiple projects with
+    different dependencies, and for ensuring that the dependencies of a project do not
+    conflict with the dependencies of the system.
+
+    To create a virtual environment for the `geneweaver-client` package.
+    ```
+    python3 -m venv geneweaver-client
+    source geneweaver-client/bin/activate
+    ```
+
+To install the `geneweaver-client` package from PyPI, run the following command:
+```bash
+pip install geneweaver-client
+```
+
+## Help Documentation
+
+All of the `gweave` commands come with built-in help. To see the help for a specific
+command, use the `--help` flag.
+
+```bash
+gweave --help
+```
+
+## Alpha & Beta Commands
+The `gweave` client is how the Geneweaver team ships early access functionality, and
+how we test new features. The `alpha` and `beta` commands are how we expose this
+functionality to the community.
+
+??? danger "Alpha Commands"
+
+    The `alpha` commands are for early access functionality. They are not guaranteed to
+    work, and they are not guaranteed to be stable. They are for testing purposes only.
+
+    They are considered to be experimental, and they may be removed or changed without
+    warning.
+
+    Alpha commands do not have the same level of testing requirements as the rest of the 
+    CLI, and may break or change in unexpected ways.
+
+    You can always see information about alpha commands, as well as all commands available
+    in the `gweave` CLI, by using the `--help` flag.
+
+    ```bash
+    gweave alpha --help
+    ```
+
+??? warning "Beta Commands"
+    The `beta` commands are for functionality that is _intended_ for general release,
+    is considered to be stable and safe to use, but which is still undergoing testing. 
+
+    There is also no guarantee that beta commands will be released beyond beta testing.
+
+    Beta commands are subject to future change and/or removal.
+
+    You can always see information about beta commands, as well as all commands available
+    in the `gweave` CLI, by using the `--help` flag.
+
+    ```bash
+    gweave beta --help
+    ```
+
+## Command Groups
+The `gweave` CLI is organized into command groups. Each command group is a collection of
+related commands. The alpha and beta commands referenced in the previous section are 
+actually two examples of these groups. 
+
+Command groups can also have nested command groups. 
+
+```
+gweaver <group> <subgroup> <command> <arguments> <options>
+```
+
+In the following example, `alpha` is a command group, and `auth` is a nested command 
+group, login is a command, and `--reauth` is an option.
+
+```
+gweaver alpha auth login --reauth
+```

--- a/docs/reference/command-line/logging-in.md
+++ b/docs/reference/command-line/logging-in.md
@@ -1,0 +1,58 @@
+# Logging In
+
+This page describes how to log in to the GeneWeaver command line application (`gweave`).
+
+## Requirements
+You will need to have installed the `gweave` tool. See 
+[Command Line Interface](/reference/command-line/#installation) for installation instructions.
+
+## The `auth` Command Group
+
+!!! tip "Still in beta!"
+    The auth command group is still in beta! In the following examples we will prepend
+    the `beta` command group to all of our examples.
+
+To log in to the command line application, we will be using the `auth` command group.
+
+??? info "Command Groups"
+    If you are not familiar with command groups, see the documentation on `gweave`
+    [Command Groups](/reference/command-line/#command-groups).
+
+### Fist Steps
+
+If you have never logged in before, the first think you will need to do is use 
+the `login` command.
+
+```
+gweaver beta auth login
+```
+
+This will prompt you to open a link in your web browser. Once you have opened the link,
+you will be prompted to log in to the GeneWeaver web application. Once you have logged 
+in, navigate back to the command line application to continue using the `gweave` tool.
+
+```
+1. On your computer or mobile device navigate to:  https://geneweaver.auth0.com/activate?user_code=SOME-CODE
+2. Enter the following code:  SOME-CODE
+```
+
+Note that the code may have been entered automatically for you, in which case you can
+continue through without entering the code.
+
+### Seeing you Tokens
+You should not need to see your tokens, but if you do, you can use the two tokens 
+commands:
+```
+gweaver beta auth print-access-token
+gweaver beta auth print-identity-token
+```
+
+### Re-authenticating
+You should not have to manually reauthenticate, but if you need to, you can use the 
+`--reauth` flag.
+
+```
+gweaver beta auth login --reauth
+```
+
+This will force the `gweave` tool to restart the loginc process from the beginning.

--- a/docs/reference/command-line/logging-in.md
+++ b/docs/reference/command-line/logging-in.md
@@ -18,9 +18,9 @@ To log in to the command line application, we will be using the `auth` command g
     If you are not familiar with command groups, see the documentation on `gweave`
     [Command Groups](/reference/command-line/#command-groups).
 
-### Fist Steps
+### First Steps
 
-If you have never logged in before, the first think you will need to do is use 
+If you have never logged in before, the first thing you will need to do is use 
 the `login` command.
 
 ```
@@ -31,6 +31,7 @@ This will prompt you to open a link in your web browser. Once you have opened th
 you will be prompted to log in to the GeneWeaver web application. Once you have logged 
 in, navigate back to the command line application to continue using the `gweave` tool.
 
+You will see the following message in your terminal:
 ```
 1. On your computer or mobile device navigate to:  https://geneweaver.auth0.com/activate?user_code=SOME-CODE
 2. Enter the following code:  SOME-CODE
@@ -39,8 +40,8 @@ in, navigate back to the command line application to continue using the `gweave`
 Note that the code may have been entered automatically for you, in which case you can
 continue through without entering the code.
 
-### Seeing you Tokens
-You should not need to see your tokens, but if you do, you can use the two tokens 
+### Viewing your Tokens
+You should not need to view your tokens, but if you do, you can use the two tokens 
 commands:
 ```
 gweaver beta auth print-access-token

--- a/docs/reference/restful-api.md
+++ b/docs/reference/restful-api.md
@@ -1,7 +1,15 @@
+# ReST APIs
 
-[//]: # (TODO)
-!!! warning "Work In Progress"
-    This page is currently under construction. Please check back later for updates.
+## Geneweaver ReST API
+The Geneweaver ReST API powers the Geneweaver web application. The API is available at
+[geneweaver-prod.jax.org/api/docs](https://geneweaver-prod.jax.org/api/docs).
 
-    For now, you can read the 
-    [documentation on the legacy API](https://geneweaver.org/help/#api).
+## Geneweaver A.O.N. ReST API
+
+The A.O.N geneweaver ortholog and homolog ReST API is a powerful tool for mapping gene 
+IDs between species. 
+
+The API is available at 
+[geneweaver-prod.jax.org/aon/api/docs](https://geneweaver-prod.jax.org/aon/api/docs).
+
+Read the paper [here](https://pubmed.ncbi.nlm.nih.gov/37891644/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,10 @@ nav:
       - tutorial/index.md
       - Client Login: tutorial/geneweaver_client_login.ipynb
       - NCI-60 Example Workflow: tutorial/nci_60_example_01.ipynb
-      - Download Genesets (CLI): tutorial/downloading_geneset_command_line.md
+#      - Geneweaver Command Line Interface:
+#          - tutorial/geneweaver_command_line.md
+#          - tutorial/geneweaver_command_line.md
+#      - Download Genesets (CLI): tutorial/downloading_geneset_command_line.md
 #      - Download Genesets: tutorial/download_genesets.ipynb
 #      - Accessing Geneweaver Data: tutorial/accessing-geneweaver-data.md
 #      - Running a Local Database: tutorial/running-a-local-database.md
@@ -91,12 +94,16 @@ nav:
 #      - Creating Documentation Sites: tutorial/creating-a-new-documentation-site.md
   - Reference:
       - reference/index.md
+      - gweave (Command Line):
+        - reference/command-line/index.md
+        - Logging In: reference/command-line/logging-in.md
+        - API Commands: reference/command-line/api-commands.md
+      - ReST API: reference/restful-api.md
       - Available Packages: reference/available-packages.md
       - Available Tools: reference/available-tools.md
-      - Scientific Workflows: reference/scientific-workflows.md
+#      - Scientific Workflows: reference/scientific-workflows.md
       - Data Model: reference/data-model.md
       - GeneSet Tiers: reference/geneset-tiers.md
       - Contributing Guide: reference/contributing-guide.md
       - Development Guide: reference/development-guide.md
-      - ReST API: reference/restful-api.md
       - Acknowledgements: reference/acknowledgements.md


### PR DESCRIPTION
This PR replace the previous downloading geneset doucment with more comprehensive documentation on using the `gweave` command line interface. It better explains the command groups and options that are referenced in the examples.